### PR TITLE
Remove katacoda, as it no longer exists

### DIFF
--- a/content/en/includes/task-tutorial-prereqs.md
+++ b/content/en/includes/task-tutorial-prereqs.md
@@ -4,5 +4,4 @@ cluster, you can create one by using
 [minikube](https://minikube.sigs.k8s.io/docs/tutorials/multi_node/)
 or you can use one of these Kubernetes playgrounds:
 
-* [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
 * [Play with Kubernetes](http://labs.play-with-k8s.com/)


### PR DESCRIPTION
Katacoda has been taken down and is no longer available.

Since there is another k8s playground, and it works, I just removed katacoda and left the other one.